### PR TITLE
Thread Warm up to speed up first bake

### DIFF
--- a/NormalSmith/Engine/BakingEngine.cs
+++ b/NormalSmith/Engine/BakingEngine.cs
@@ -1678,7 +1678,7 @@ namespace NormalSmith.Engine
         private static int ColorToInt(Vector3 normal, Vector3 swizzle)
         {
             normal.X *= swizzle.X;
-            normal.Y *= swizzle.Y;
+            normal.Y *= -swizzle.Y;
             normal.Z *= swizzle.Z;
 
             int r = (int)Math.Clamp((normal.X * 0.5f + 0.5f) * 255, 0, 255);

--- a/NormalSmith/MainWindow.xaml.cs
+++ b/NormalSmith/MainWindow.xaml.cs
@@ -136,6 +136,8 @@ namespace NormalSmith
         /// </summary>
         private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
+            WarmUpThreadPool();
+
             this.Title = "Normal Smith v" + newTitle.Remove(newTitle.Length-2);
 
             // Load dark mode preference.
@@ -933,6 +935,29 @@ namespace NormalSmith
         #endregion
 
         #region Utility Methods
+        /// <summary>
+        /// Warms up the ThreadPool by setting the minimum number of threads and running a dummy parallel loop.
+        /// </summary>
+        private void WarmUpThreadPool()
+        {
+            // Retrieve current minimum thread counts.
+            int workerThreads, completionPortThreads;
+            ThreadPool.GetMinThreads(out workerThreads, out completionPortThreads);
+
+            // Set the minimum worker threads to (ProcessorCount * 2) if not already higher.
+            int minWorker = Environment.ProcessorCount * 2;
+            if (workerThreads < minWorker)
+            {
+                ThreadPool.SetMinThreads(minWorker, completionPortThreads);
+            }
+
+            // Run a dummy parallel loop to force the ThreadPool to create the necessary worker threads.
+            Parallel.For(0, minWorker, i =>
+            {
+                // A trivial computation to warm up each thread.
+                double dummy = Math.Sqrt(i);
+            });
+        }
         /// <summary>
         /// Converts a System.Drawing.Bitmap to a WPF BitmapSource.
         /// </summary>


### PR DESCRIPTION
Usually on the first bake after launch, the threads won't fully saturate. Now include a Warm up routine so that all threads can be used full on the first bake.